### PR TITLE
Update debian version to latest stable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Starting point
-FROM debian:stable
+FROM debian:latest
 
 # Start in the DocumentRoot
 WORKDIR /var/www/html


### PR DESCRIPTION
The debian:latest tag will always point the latest stable release

Source: https://hub.docker.com/_/debian/